### PR TITLE
Add tests for monkeys

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM node
+
+# to properly install node-gyp package
+ENV USER root
+
+# so that npm installs not into the code path, so we can share this directory
+# and still have npm_modules not shared
+RUN mkdir -p /install/
+# so that executable from modules are added to the path
+ENV PATH /install/node_modules/.bin:$PATH
+# so that you can require('..') a global module
+ENV NODE_PATH /install/node_modules/
+
+COPY ./package.json /install/package.json
+RUN cd install; npm install
+# # so that it installs global modules into /install/lib/node_modules
+# ENV NPM_CONFIG_PREFIX=/install/
+# # so that it install in global location by default
+# ENV NPM_CONFIG_GLOBAL=true
+
+
+WORKDIR /src/
+COPY . /src/
+
+CMD npm run test:watch

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ You can download the Chrome debugger [here](https://chrome.google.com/webstore/d
 
 ### Instantiate a Cerebral controller
 *controller.js*
+
 ```js
 import Controller from 'cerebral';
 import Model from 'cerebral-baobab';
@@ -34,7 +35,7 @@ const model = Model({
 
 // You have access to the Baobab tree itself
 model.tree.on('invalid', function () {
-  
+
 });
 
 // Any utils you want each action to receive
@@ -45,6 +46,7 @@ const services = {
 // Instantiate the controller
 export default Controller(model, services);
 ```
+
 With Baobab you can also map state using facets, read more about that [here](https://github.com/Yomguithereal/baobab/issues/278).
 
 ### Creating signals
@@ -53,6 +55,7 @@ Creating actions are generic. It works the same way across all packages. You can
 Typically you would create your signals in the *main.js* file, but you can split them out as you see fit.
 
 *main.js*
+
 ```js
 import controller from './controller.js';
 
@@ -68,6 +71,7 @@ controller.signal('formSubmitted', setLoading, [saveForm], unsetLoading);
 You can manually listen to changes on the controller, in case you want to explore [reactive-router](https://github.com/christianalfoni/reactive-router) for example.
 
 *main.js*
+
 ```js
 import controller from './controller.js';
 
@@ -86,6 +90,7 @@ controller.removeListener('remember', onChange);
 You can listen to errors in the controller. Now, Cerebral helps you a lot to avoid errors, but there are probably scenarios you did not consider. By using the error event you can indicate messages to the user and pass these detailed error messages to a backend service. This lets you quickly fix bugs in production.
 
 *main.js*
+
 ```js
 ...
 const onError = function (error) {

--- a/npm-debug.log
+++ b/npm-debug.log
@@ -1,0 +1,37 @@
+0 info it worked if it ends with ok
+1 verbose cli [ '/usr/local/bin/node', '/usr/local/bin/npm', 'run', 'test' ]
+2 info using npm@2.14.4
+3 info using node@v4.1.2
+4 verbose run-script [ 'pretest', 'test', 'posttest' ]
+5 info pretest cerebral-baobab@0.3.0
+6 info test cerebral-baobab@0.3.0
+7 verbose unsafe-perm in lifecycle true
+8 info cerebral-baobab@0.3.0 Failed to exec test script
+9 verbose stack Error: cerebral-baobab@0.3.0 test: `node --harmony --harmony_destructuring tests/*.js | tap-dot`
+9 verbose stack Exit status 1
+9 verbose stack     at EventEmitter.<anonymous> (/usr/local/lib/node_modules/npm/lib/utils/lifecycle.js:214:16)
+9 verbose stack     at emitTwo (events.js:87:13)
+9 verbose stack     at EventEmitter.emit (events.js:172:7)
+9 verbose stack     at ChildProcess.<anonymous> (/usr/local/lib/node_modules/npm/lib/utils/spawn.js:24:14)
+9 verbose stack     at emitTwo (events.js:87:13)
+9 verbose stack     at ChildProcess.emit (events.js:172:7)
+9 verbose stack     at maybeClose (internal/child_process.js:818:16)
+9 verbose stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:211:5)
+10 verbose pkgid cerebral-baobab@0.3.0
+11 verbose cwd /src
+12 error Linux 4.0.9-boot2docker
+13 error argv "/usr/local/bin/node" "/usr/local/bin/npm" "run" "test"
+14 error node v4.1.2
+15 error npm  v2.14.4
+16 error code ELIFECYCLE
+17 error cerebral-baobab@0.3.0 test: `node --harmony --harmony_destructuring tests/*.js | tap-dot`
+17 error Exit status 1
+18 error Failed at the cerebral-baobab@0.3.0 test script 'node --harmony --harmony_destructuring tests/*.js | tap-dot'.
+18 error This is most likely a problem with the cerebral-baobab package,
+18 error not with npm itself.
+18 error Tell the author that this fails on your system:
+18 error     node --harmony --harmony_destructuring tests/*.js | tap-dot
+18 error You can get their info via:
+18 error     npm owner ls cerebral-baobab
+18 error There is likely additional logging output above.
+19 verbose exit [ 1, true ]


### PR DESCRIPTION
I added some tests here for monkey behavior and laziness.

Two of them are currently failing.

First, it looks like monkeys are evaluated when the state is initially created. Is this behavior unavoidable?

Second, monkeys seem to be evaluated whenever one of their dependent paths are updated. Instead, they should only be re-calculated when actually asked for. This is what [baobab says](https://github.com/Yomguithereal/baobab#computed-data-or-monkey-business) at least:

> - The dynamic nodes are lazy and won't actually be computed before you get them (plus they will only compute once before they need to change, so if you get the same dynamic node twice, the computation won't rerun).

This doesn't do any checking of react+baobab which might destroy this laziness anyway, if it asks for all the monkey each time it recreates the tree.

I am happy to change testing frameworks, just used Tape because I have used it before. Also, it [integrates super easily with zuul](https://github.com/daedelus-j/zuul-tape-testing), so we could add cross browser testing easily and cheaply, which might be a good idea.
