### PR TITLE
Bugfix: Missing parameters in concat function

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ var Model = function (initialState, options) {
           merge: function (path, value) {
             tree.merge(path, value);
           },
-          concat: function () {
+          concat: function (path, value) {
             tree.apply(path, function (existingValue) {
               return existingValue.concat(value);
             });


### PR DESCRIPTION
The parameters path and value are missing in the concat function
