### PR TITLE
Update baobab for monkey merge fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   },
   "homepage": "https://github.com/christianalfoni/cerebral-baobab#readme",
   "dependencies": {
-    "baobab": "^2.3.0"
+    "baobab": "^2.3.3"
   }
 }


### PR DESCRIPTION
Cerebral-model-baobab's merge on reset can cause Yomguithereal/baobab#430 to
occur and keys around monkeys are incorrectly dropped form the state. Baobab
2.3.3 fixes the issue.
